### PR TITLE
updated link to css file in docs

### DIFF
--- a/docs/config/templates/indexPage.template.html
+++ b/docs/config/templates/indexPage.template.html
@@ -3,7 +3,7 @@
 <head lang="en">
     <meta charset="UTF-8">
     <title>Semantic-UI-Angular</title>
-    <link rel="stylesheet" href="lib/semantic-ui/semantic.css"/>
+    <link rel="stylesheet" href="lib/semantic-ui-css/semantic.css"/>
 </head>
 <body>
 <div class="ui page grid">


### PR DESCRIPTION
I downloaded and ran gulp, and ended up with a documentation page that does not do anything and has a bad link to the css file. I've fixed the latter but it looks as though the docs need more work. I'm happy to help but i need some instructions to install setup so I can even begin... 