### PR TITLE
Add commitizen configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Semantic-UI-Angular
 [![Build Status](https://travis-ci.org/Semantic-Org/Semantic-UI-Angular.svg)](https://travis-ci.org/Semantic-Org/Semantic-UI-Angular)
 [![Dependency Status](https://david-dm.org/Semantic-Org/Semantic-UI-Angular.svg)](https://david-dm.org/Semantic-Org/Semantic-UI-Angular)
 [![devDependency Status](https://david-dm.org/Semantic-Org/Semantic-UI-Angular/dev-status.svg)](https://david-dm.org/Semantic-Org/Semantic-UI-Angular#info=devDependencies)
+[![Commitizen friendly](https://img.shields.io/badge/commitizen-friendly-brightgreen.svg)](http://commitizen.github.io/cz-cli/)
 
 **Semantic-UI-Angular** is a pure AngularJS 1.x set of directives for Semantic-UI components.
 We are considering Angular 2 support in the future. We've decided to use TypeScript as a step to Angular 2 friendly environment.

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "devDependencies": {
     "angular": "1.4.8",
     "angular-mocks": "1.4.8",
+    "cz-conventional-changelog": "^1.1.5",
     "jasmine-core": "2.4.1",
     "jquery": "2.2.0",
     "jscs": "2.8.0",
@@ -47,5 +48,10 @@
     "tslint-loader": "2.1.0",
     "typescript": "1.7.5",
     "webpack": "1.12.10"
+  },
+  "config": {
+    "commitizen": {
+      "path": "./node_modules/cz-conventional-changelog"
+    }
   }
 }


### PR DESCRIPTION
This commit initializes the repo with the cz-conventional-changelog module.

To use, first install the commitizen CLI globally:

`npm install -g commitizen`

Next, make sure to run `npm install` to install any missing dependencies (in this case, the cz-conventional-changelog module). 

Now, whenever you want to commit, first stage your changes e.g. `git add --all` and then commit using `git cz` and follow the prompts. 

All of this info will be added to the CONTRIBUTING.MD, which I will issue a PR for separately.