### PR TITLE
chore(project): ignore js and map files in src

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@
 typings
 npm-debug.log
 .vscode
+src/**/*.js
+src/**/*.map


### PR DESCRIPTION
When `tsc` is run - either manually, or in my case, by the `atom-typescript` project in Atom when I save a .ts file - it generates .js and .map files in place for each typescript file in the project. Since these are compilation artifacts, I'm suggesting we ignore them.